### PR TITLE
Use `nbin` for bootstrapping to avoid clashes with people using `~/.local/bin` for their hacks

### DIFF
--- a/boostrap_home_manager.sh
+++ b/boostrap_home_manager.sh
@@ -9,7 +9,7 @@ git clone https://github.com/cognivore/nix-home.git
 
 ## First populate .local/bin which has some spicy stuff for convenience CLI scripts
 mkdir ~/.local
-git clone https://github.com/cognivore/local-bin.git ~/.local/bin
+git clone https://github.com/cognivore/local-bin.git ~/.local/nbin
 
 ## Then link stuff in ~/.config (assuming you cloned this repo into ~/nix-home)
 mkdir ~/.config
@@ -17,6 +17,10 @@ ln -sT "${HOME}/nix-home/nix" ~/.config/nix
 ln -sT "${HOME}/nix-home/nixpkgs" ~/.config/nixpkgs
 
 cat <<BEEP
+Add ~/.local/nbin to your PATH:
+
+
+
 Edit your ~/.config/nixpkgs/home.nix:
  - [ ] Set home.username to $(whoami).
  - [ ] Set home.homeDirectory to ${HOME}.

--- a/nixpkgs/home.nix
+++ b/nixpkgs/home.nix
@@ -22,5 +22,5 @@
   programs.direnv.enable = true;
   programs.direnv.nix-direnv.enable = true;
 
-  home.packages = [] ++ (import ../../.local/bin/home-manager.nix {pkgs = pkgs;});
+  home.packages = [] ++ (import ../../.local/nbin/home-manager.nix {pkgs = pkgs;});
 }


### PR DESCRIPTION
Ditto
